### PR TITLE
Add src prop to CardImage

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -16,7 +16,17 @@ export const CardHeader = bulmaComponent('header', 'card-header',
     ].concat(props.children).filter(Boolean)
   }))
 )
-export const CardImage = bulmaComponent('div', 'card-image')
+export const CardImage = bulmaComponent('div', 'card-image',
+  mapProps(({ src, children, ...props }) => ({
+    ...props,
+    // TODO Perhaps throw if both src and children are provided?
+    children: src && !children ? (
+      <figure className='image'>
+        <img {...props} src={src} />
+      </figure>
+    ) : children
+  }))
+)
 export const CardContent = bulmaComponent('div', 'card-content')
 export const CardFooter = bulmaComponent('footer', 'card-footer')
 export const CardFooterItem = bulmaComponent('span', 'card-footer-item')


### PR DESCRIPTION
`<CardImage src="xyz" />` is a shorthand for

```js
<CardImage>
  <figure className="image">
    <img src="xyz" />
  </figure>
</CardImage>
```

Not sure if this is a good idea since there are two different elements that you may want to send props to here (the `<CardImage>` wrapper and the `<img>` itself)